### PR TITLE
Add FreeBSD/OpenBSD support.

### DIFF
--- a/locale_freebsd.go
+++ b/locale_freebsd.go
@@ -1,0 +1,9 @@
+// +build !unit_test
+
+package locale
+
+var detectors = []detector{
+	detectViaEnvLanguage,
+	detectViaEnvLc,
+	detectViaLocale,
+}

--- a/locale_openbsd.go
+++ b/locale_openbsd.go
@@ -1,0 +1,9 @@
+// +build !unit_test
+
+package locale
+
+var detectors = []detector{
+	detectViaEnvLanguage,
+	detectViaEnvLc,
+	detectViaLocale,
+}


### PR DESCRIPTION
Since there's no definition for ``detectors`` for either [Free/Open]BSD it'll fail to build:

```console
(lcook@darkstar:go-locale) (git)[master:2bb2ed4]
% uname -a
FreeBSD darkstar 12.1-RELEASE-p3 FreeBSD 12.1-RELEASE-p3 GENERIC  amd64
(lcook@darkstar:go-locale) (git)[master:2bb2ed4]
% go build
# github.com/Xuanwo/go-locale
./locale.go:40:21: undefined: detectors
```

Adding both ``locale_freebsd`` and ``locale_openbsd`` provides that definition and subsequently fixes this. 