### PR TITLE
windows: Detecting Windows locale using Windows Registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/go-ole/go-ole v1.2.4
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
 	golang.org/x/text v0.3.2
 )

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/locale_windows_test.go
+++ b/locale_windows_test.go
@@ -20,3 +20,16 @@ func TestDetectViaWin32OLE(t *testing.T) {
 		})
 	})
 }
+
+func Test_detectViaWinRegistry(t *testing.T) {
+	Convey("detect via Windows Registry", t, func() {
+		langs, err := detectViaWinRegistry()
+
+		Convey("The error should not be nil", func() {
+			So(err, ShouldBeNil)
+		})
+		Convey("The langs should not be empty", func() {
+			So(langs, ShouldNotBeEmpty)
+		})
+	})
+}


### PR DESCRIPTION
As mentioned in #19 using Windows registry is also a valid, in my test cases more reliable way of detecting locale (and many other Internationalization settings for the future - like money, time and number formatting, etc.).