### PR TITLE
Simplify and benchmark Detect function

### DIFF
--- a/locale.go
+++ b/locale.go
@@ -8,11 +8,11 @@ import (
 
 // Detect will detect current env's language.
 func Detect() (tag language.Tag, err error) {
-	tags, err := DetectAll()
+	lang, err := detect()
 	if err != nil {
 		return language.Und, err
 	}
-	return tags[0], nil
+	return language.Make(lang[0]), nil
 }
 
 // DetectAll will detect current env's all available language.

--- a/locale_test.go
+++ b/locale_test.go
@@ -75,6 +75,7 @@ func TestDetect(t *testing.T) {
 		expectError error
 	}{
 		{"normal", []string{"en-US"}, nil, language.AmericanEnglish, nil},
+		{"invalid", []string{"ac"}, nil, language.Und, nil},
 		{"not detected", nil, ErrNotDetected, language.Und, ErrNotDetected},
 	}
 
@@ -90,6 +91,15 @@ func TestDetect(t *testing.T) {
 				t.Errorf("Detect() = %v, want %v", lang, tt.expectLang)
 			}
 		})
+	}
+}
+
+func BenchmarkDetect(b *testing.B) {
+	detectors = []detector{mockLang.get}
+
+	mockLang.set([]string{"en-US"}, nil)
+	for i := 0; i < b.N; i++ {
+		Detect()
 	}
 }
 


### PR DESCRIPTION
This makes the Detect function slightly faster by not allocating a `[]language.Tag` with all the results before just using the first one.